### PR TITLE
feature: allow withspaces around variable names

### DIFF
--- a/src/GherkinParam.php
+++ b/src/GherkinParam.php
@@ -37,7 +37,7 @@ class GherkinParam extends \Codeception\Extension
    * @var array RegExp for parsing steps
    */
   private static $regEx = [
-    'match'  => '/^{{[A-z0-9_:-]+}}$/',
+    'match'  => '/^{{\s?[A-z0-9_:-]+\s?}}$/',
     'filter' => '/[{}]/',
     'config' => '/(?:^config)?:([A-z0-9_-]+)+(?=:|$)/',
     'array'  => '/^(?P<var>[A-z0-9_-]+)(?:\[(?P<key>.+)])$/'
@@ -53,7 +53,7 @@ class GherkinParam extends \Codeception\Extension
   final protected function getValueFromParam(string $param)
   {
     if (preg_match(self::$regEx['match'], $param)) {
-      $arg = preg_filter(self::$regEx['filter'], '', $param);
+      $arg = trim(preg_filter(self::$regEx['filter'], '', $param));
       if (preg_match(self::$regEx['config'], $arg)) {
         return $this->getValueFromConfig($arg);
       } elseif (preg_match(self::$regEx['array'], $arg)) {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -31,7 +31,7 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
-     * @Then /^I should see "({{[A-z0-9\[\]_:-]+}})" equals (?:to )?(?:")?([^"]+)(?:")?$/i
+     * @Then /^I should see "({{\s?[A-z0-9\[\]_:-]+\s?}})" equals (?:to )?(?:")?([^"]+)(?:")?$/i
      */
      public function iSeeEqual($arg1, $arg2)
      {

--- a/tests/acceptance/GherkinParam.feature
+++ b/tests/acceptance/GherkinParam.feature
@@ -6,6 +6,7 @@ Feature: Parametrize Gherkin Feature
   Scenario: Scenario using simple parameter
     Given I have a parameter "test" with value "42"
     Then I should see "{{test}}" equals "42"
+    Then I should see "{{ test }}" equals "42"
 
   Scenario: Scenario using table parameter
     Given I have a parameter "my_param" with value "This is a test"
@@ -13,7 +14,7 @@ Feature: Parametrize Gherkin Feature
     Then I should see following:
       | parameter         | equals to      |
       | {{my_param}}      | This is a test |
-      | {{another_param}} | 3.14           |
+      | {{ another_param }} | 3.14           |
 
   Scenario Outline: Scenario using example
     Given I have a parameter "test" with value "param"
@@ -26,11 +27,14 @@ Feature: Parametrize Gherkin Feature
 
   Scenario: Scenario using table in helper
     Given I have a parameter "test" with value "Table Node"
+    And I have a parameter "another_param" with value "3.14"
     When I have parameters
         | parameter | value      |
         | param1    | Fix Helper |
         | param2    | {{test}}   |
+        | param3    | {{ another_param }}   |
     Then I should see "{{param2}}" equals "{{test}}"
+    Then I should see "{{param3}}" equals "{{another_param}}"
 
   Scenario: Scenario using JSON string
     Given I have a parameter "test" with value "{'value': 42}"

--- a/tests/acceptance/GherkinParamArray.feature
+++ b/tests/acceptance/GherkinParamArray.feature
@@ -6,7 +6,7 @@ Feature: Parametrize Gherkin Feature (Array)
   Scenario: Get array parameters
     Given I have an array "test" with values [1, two, 3.14, IV, 101]
     Then I should see "{{test[0]}}" equals to 1
-    And I should see "{{test[1]}}" equals to "two"
+    And I should see "{{ test[1] }}" equals to "two"
     And I should see "{{test[2]}}" equals to 3.14
     And I should see "{{test[3]}}" equals to "IV"
     And I should see "{{test[4]}}" equals to "101"

--- a/tests/acceptance/GherkinParamConfig.feature
+++ b/tests/acceptance/GherkinParamConfig.feature
@@ -43,7 +43,7 @@ Feature: Parametrize Gherkin Feature (Config)
       some_param: 42
       """
     When I execute a scenario calling the parameter 'some_param'
-    Then I should see "{{config:some_param}}" equals "42"
+    Then I should see "{{ config:some_param }}" equals "42"
 
     Scenario: Parameters array format
       Given I have a configuration file "codeception.yml"


### PR DESCRIPTION
Allow whitespaces around variable names `{{ my_var }}`.
