### PR TITLE
feature: allow multiple variables and variables with additional text

### DIFF
--- a/src/GherkinParam.php
+++ b/src/GherkinParam.php
@@ -66,6 +66,10 @@ class GherkinParam extends \Codeception\Extension
         }
       }
       $param = str_replace($variables[0], $values, $param);
+
+      if (count($values) === 1 && $values[0] === null) {
+        return null;
+      }
     }
 
     return $param;

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -31,7 +31,7 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
-     * @Then /^I should see "({{\s?[A-z0-9\[\]_:-]+\s?}})" equals (?:to )?(?:")?([^"]+)(?:")?$/i
+     * @Then /^I should see "([^"]+)" equals (?:to )?(?:")?([^"]+)(?:")?$/i
      */
      public function iSeeEqual($arg1, $arg2)
      {

--- a/tests/acceptance/GherkinParam.feature
+++ b/tests/acceptance/GherkinParam.feature
@@ -8,6 +8,11 @@ Feature: Parametrize Gherkin Feature
     Then I should see "{{test}}" equals "42"
     Then I should see "{{ test }}" equals "42"
 
+  Scenario: Scenario with multiple values
+    Given I have a parameter "first_param" with value "first"
+    Given I have a parameter "second_param" with value "second"
+    Then I should see "{{first_param}} and {{second_param}}" equals "first and second"
+
   Scenario: Scenario using table parameter
     Given I have a parameter "my_param" with value "This is a test"
     And I have a parameter "another_param" with value "3.14"

--- a/tests/acceptance/GherkinParamArray.feature
+++ b/tests/acceptance/GherkinParamArray.feature
@@ -10,6 +10,7 @@ Feature: Parametrize Gherkin Feature (Array)
     And I should see "{{test[2]}}" equals to 3.14
     And I should see "{{test[3]}}" equals to "IV"
     And I should see "{{test[4]}}" equals to "101"
+    And I should see "{{test[4]}} and {{test[1]}}" equals "101 and two"
 
   Scenario: Key not exist (exception)
     Given I have an array "test" with values [1, two, 3.14, IV, 101]

--- a/tests/acceptance/GherkinParamConfig.feature
+++ b/tests/acceptance/GherkinParamConfig.feature
@@ -29,6 +29,7 @@ Feature: Parametrize Gherkin Feature (Config)
       """
     When I execute a scenario calling the parameter 'my_param:user'
     Then I should see "{{config:my_param:user}}" equals "mylogin"
+    Then I should see "{{config:my_param:user}}:{{config:my_param:password}}" equals "mylogin:mypassword"
 
   Scenario: Suite parameters from acceptance.suite.yml
     Given I have a configuration file "acceptance.suite.yml"


### PR DESCRIPTION
This allow multiple variables and additional text in arguments.

`{{first_param}} and {{second_param}}`
` my value is {{first_param}}`

There are 2 failing testcases:
1) Parametrize Gherkin Feature (Array): Key not exist (exception)
 Test  tests/acceptance/GherkinParamArray.feature:Key not exist (exception)
 Step  I should see "{{test[9999]}}" is null 
 Fail  Failed asserting that '' is null.

2) Parametrize Gherkin Feature (Config): Config key not exists (expect null)
 Test  tests/acceptance/GherkinParamConfig.feature:Config key not exists (expect null)
 Step  I should see "{{config:not_a_param}}" is null 
 Fail  Failed asserting that '' is null.

What should be the value for `{{first_param}} and {{second_param}}` when one variable was not set?

I think it would be more logical when the variable not exist. The argument is unchanged. For example

`{{config:not_a_param}}` would be `{{config:not_a_param}}` and not `null`

This way it is also easier to debug when a variable was not set.
