### PR TITLE
inconsistent variable or key not found 

### DIFF
--- a/tests/acceptance/GherkinParam.feature
+++ b/tests/acceptance/GherkinParam.feature
@@ -8,6 +8,10 @@ Feature: Parametrize Gherkin Feature
     Then I should see "{{test}}" equals "42"
     Then I should see "{{ test }}" equals "42"
 
+  Scenario: variable does not exist (exception)
+    Given I have a parameter "first" with value "42"
+    Then I should see "{{second}}" is null
+
   Scenario: Scenario using table parameter
     Given I have a parameter "my_param" with value "This is a test"
     And I have a parameter "another_param" with value "3.14"

--- a/tests/acceptance/GherkinParamArray.feature
+++ b/tests/acceptance/GherkinParamArray.feature
@@ -11,6 +11,10 @@ Feature: Parametrize Gherkin Feature (Array)
     And I should see "{{test[3]}}" equals to "IV"
     And I should see "{{test[4]}}" equals to "101"
 
+  Scenario: variable does not exist (exception)
+    Given I have an array "test" with values [1, two, 3.14, IV, 101]
+    Then I should see "{{second}}" is null
+
   Scenario: Key not exist (exception)
     Given I have an array "test" with values [1, two, 3.14, IV, 101]
     Then I should see "{{test[9999]}}" is null

--- a/tests/acceptance/GherkinParamConfig.feature
+++ b/tests/acceptance/GherkinParamConfig.feature
@@ -122,3 +122,30 @@ Feature: Parametrize Gherkin Feature (Config)
       """
     When I execute a scenario calling the parameter 'config:not_a_param'
     Then I should see "{{config:not_a_param}}" is null
+
+  Scenario: Config key not exists (expect null)
+    Given I have a configuration file "codeception.yml"
+          """
+          actor: Tester
+
+          paths:
+            tests: tests
+            log: tests/_output
+            data: tests/_data
+            support: tests/_support
+            envs: tests/_envs
+
+          settings:
+            bootstrap: _bootstrap.php
+            colors: true
+            memory_limit: 512M
+            my_edgecase:
+              0:
+                user: 'edgecase'
+
+          extensions:
+              enabled:
+                  - Codeception\Extension\GherkinParam
+          """
+    When I execute a scenario calling the parameter 'my_edgecase:1:user'
+    Then I should see "{{config:my_edgecase:1:user}}" equals "edgecase"


### PR DESCRIPTION
The actual behaviour is inconsistent.

|        | variable not exist | key not exist       |
|--------|--------------------|---------------------|
| param  | exception          | -                   |
| array  | exception          | null                |
| config | null               | array last matching |

I have added test for it. see also discussion #20 