### PR TITLE
Fix Travis failure due to xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ branches:
   only:
     - master
 
+env:
+  global:
+      - XDEBUG_MODE=coverage
+
 php:
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+
+jobs:
+  allow_failures:
+    - php: 8.0
 
 before_script:
   - composer install


### PR DESCRIPTION
Fix xdebug issue as suggested in https://travis-ci.community/t/xdebug-3-is-installed-by-default-breaking-builds/10748/2